### PR TITLE
add omit-core option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ Defaults to `MYMETA.json MYMETA.yml META.json META.yml Makefile _build/params cp
 
 A list of regular expressions of prerequisites to exclude. One pattern per line.
 
+### `omit-core`
+
+A boolean value to exclude core only modules from the output. Enabled by
+default.
+
 ## Outputs
 
 ### `perl`

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'Include prerequisites from all sources rather than only the first'
     required: false
     default: false
+  omit-core:
+    description: 'Omit core-only prerequisites'
+    required: false
+    default: true
 
 outputs:
   perl:

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -21,6 +21,7 @@ export const run = async (argv) => {
         boolean: [
           'perl',
           'allSources',
+          'omitCore',
         ],
         string: [
           'phases',
@@ -35,6 +36,7 @@ export const run = async (argv) => {
           features:      'feature',
           sources:       'source',
           allSources:    ['all-sources', 'all'],
+          omitCore:      ['omit-core'],
         },
       }),
     ).map(([k, v]) => {

--- a/src/get-prereqs.mjs
+++ b/src/get-prereqs.mjs
@@ -40,6 +40,35 @@ const parsers = [
   [/Makefile.PL$/i, parseMakefilePL],
 ];
 
+const coreModules = [
+  'B',
+  'B::Deparse',
+  'Config',
+  'DynaLoader',
+  'English',
+  'POSIX',
+  'Symbol',
+  'UNIVERSAL',
+  'blib',
+  'bytes',
+  'charnames',
+  'deprecate',
+  'feature',
+  'integer',
+  'lib',
+  'open',
+  'overload',
+  'overloading',
+  're',
+  'sort',
+  'strict',
+  'utf8',
+  'vars',
+  'warnings',
+];
+
+const coreMatch = new RegExp(`^(?:${coreModules.join('|')})$`);
+
 const parserFor = (file) => {
   for (const [pattern, parser] of parsers) {
     if (file.match(pattern)) {
@@ -74,8 +103,13 @@ export const getPrereqs = async ({
   ],
   excludes = [],
   allSources = false,
+  omitCore = true,
 }) => {
   const prereqs = {};
+
+  if (omitCore) {
+    excludes = [...excludes, coreMatch];
+  }
 
   for (const source of sources) {
     const parser = parserFor(source);

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -9,6 +9,7 @@ export const run = async () => {
   const sourcesInput = core.getInput('sources');
   const excludeInput = core.getMultilineInput('exclude');
   const allSources = core.getBooleanInput('all-sources');
+  const omitCore = core.getBooleanInput('omit-core');
 
   const phases = new Set(phasesInput.split(/\s+/));
   const relationships = new Set(relationshipsInput.split(/\s+/));
@@ -23,6 +24,7 @@ export const run = async () => {
     sources,
     excludes,
     allSources,
+    omitCore,
   });
 
   if (perl) {


### PR DESCRIPTION
The option will omit all core prereqs from the output. It is enabled by default.